### PR TITLE
Ignore parent .eslintrc files by setting root=true

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "es6": true
   },


### PR DESCRIPTION
When cloning this repo from within a script in apitwo, the linting job uses both the eslint config in this repo as well as the one from apitwo. This forces it to only look at the config in this repo and not any parent eslint configs.