### PR TITLE
Fix links to nonexistent String type

### DIFF
--- a/docs/AudioApi.md
+++ b/docs/AudioApi.md
@@ -241,7 +241,7 @@ audioApi.deleteSoundboxItems(collectionId, tracksToRemove)
 Name | Type | Description
 ------------- | ------------- | -------------
  id (required) | String| Collection ID 
- item_id | [[String]](String.md)| One or more item IDs to remove from the collection 
+ item_id | [String]| One or more item IDs to remove from the collection
 
 ### Accepted authentication
 
@@ -1048,7 +1048,7 @@ api.getTrackList(id, queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| One or more audio IDs 
+ id (required) | [String]| One or more audio IDs
  view | String| Amount of detail to render in the response, defaults to minimal <br/><br/>Valid values: "minimal", "full"
 
 ### Accepted authentication
@@ -1299,17 +1299,17 @@ audioApi.searchAudio(queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- artists | [[String]](String.md)| Show tracks with one of the specified artist names or IDs 
+ artists | [String]| Show tracks with one of the specified artist names or IDs
  bpm | Number| (Deprecated; use bpm_from and bpm_to instead) Show tracks with the specified beats per minute 
  bpm_from | Number| Show tracks with the specified beats per minute or faster 
  bpm_to | Number| Show tracks with the specified beats per minute or slower 
  duration | Number| Show tracks with the specified duration in seconds 
  duration_from | Number| Show tracks with the specified duration or longer in seconds 
  duration_to | Number| Show tracks with the specified duration or shorter in seconds 
- genre | [[String]](String.md)| Show tracks with each of the specified genres; to get the list of genres, use `GET /v2/audio/genres` 
+ genre | [String]| Show tracks with each of the specified genres; to get the list of genres, use `GET /v2/audio/genres`
  is_instrumental | Boolean| Show instrumental music only 
- instruments | [[String]](String.md)| Show tracks with each of the specified instruments; to get the list of instruments, use `GET /v2/audio/instruments` 
- moods | [[String]](String.md)| Show tracks with each of the specified moods; to get the list of moods, use `GET /v2/audio/moods` 
+ instruments | [String]| Show tracks with each of the specified instruments; to get the list of instruments, use `GET /v2/audio/instruments`
+ moods | [String]| Show tracks with each of the specified moods; to get the list of moods, use `GET /v2/audio/moods`
  page | Number| Page number, defaults to 1 
  per_page | Number| Number of results per page, defaults to 20 
  query | String| One or more search terms separated by spaces 

--- a/docs/ComputerVisionApi.md
+++ b/docs/ComputerVisionApi.md
@@ -136,7 +136,7 @@ computerVisionApi.uploadImage(body)
 Name | Type | Description
 ------------- | ------------- | -------------
  asset_id (required) | String| The asset ID or upload ID to find similar images for 
- license | [[String]](String.md)| Show only images with the specified license <br/><br/>Valid values: "commercial", "editorial"
+ license | [String]| Show only images with the specified license <br/><br/>Valid values: "commercial", "editorial"
  safe | Boolean| Enable or disable safe search, defaults to true 
  language | String| Language for the keywords and categories in the response <br/><br/>Valid values: "cs", "da", "de", "en", "es", "fi", "fr", "hu", "it", "ja", "ko", "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr", "zh", "zh-Hant"
  page | Number| Page number, defaults to 1 
@@ -441,7 +441,7 @@ computerVisionApi.uploadImage(body)
 Name | Type | Description
 ------------- | ------------- | -------------
  asset_id (required) | String| The asset ID or upload ID to find similar videos for 
- license | [[String]](String.md)| Show only videos with the specified license <br/><br/>Valid values: "commercial", "editorial"
+ license | [String]| Show only videos with the specified license <br/><br/>Valid values: "commercial", "editorial"
  safe | Boolean| Enable or disable safe search, defaults to true 
  language | String| Language for the keywords and categories in the response <br/><br/>Valid values: "cs", "da", "de", "en", "es", "fi", "fr", "hu", "it", "ja", "ko", "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr", "zh", "zh-Hant"
  page | Number| Page number, defaults to 1 

--- a/docs/ContributorsApi.md
+++ b/docs/ContributorsApi.md
@@ -393,7 +393,7 @@ api.getContributorList(id)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| One or more contributor IDs 
+ id (required) | [String]| One or more contributor IDs
 
 ### Accepted authentication
 

--- a/docs/CustomMusicApi.md
+++ b/docs/CustomMusicApi.md
@@ -418,7 +418,7 @@ customMusicApi.fetchRenders(renders)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| One or more render IDs 
+ id (required) | [String]| One or more render IDs
 
 ### Accepted authentication
 
@@ -791,7 +791,7 @@ Name | Type | Description
  band_name | String| Show descriptors with the specified band name (case-sensitive) 
  page | Number| Page number, defaults to 1 
  per_page | Number| Number of results per page, defaults to 20 
- id | [[String]](String.md)| Show descriptors with the specified IDs (case-sensitive) 
+ id | [String]| Show descriptors with the specified IDs (case-sensitive)
  instrument_name | String| Show descriptors with the specified instrument name (case-sensitive) 
  instrument_id | String| Show descriptors with the specified instrument ID (case-sensitive) 
  tempo_to | Number| Show descriptors with a tempo that is less than or equal to the specified number 
@@ -918,7 +918,7 @@ customMusicApi.listInstruments(queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id | [[String]](String.md)| Show instruments with the specified ID 
+ id | [String]| Show instruments with the specified ID
  per_page | Number| Number of results per page, defaults to 20 
  page | Number| Page number, defaults to 1 
  name | String| Show instruments with the specified name (case-sensitive) 

--- a/docs/EditorialImagesApi.md
+++ b/docs/EditorialImagesApi.md
@@ -1362,7 +1362,7 @@ Name | Type | Description
  date_taken_end | String| Show images that were taken before the specified date 
  cursor | String| The cursor of the page with which to start fetching results; this cursor is returned from previous requests 
  sort | String| Sort by, defaults to newest <br/><br/>Valid values: "newest", "oldest"
- supplier_code | [[String]](String.md)| Show only editorial content from certain suppliers 
+ supplier_code | [String]| Show only editorial content from certain suppliers
  per_page | Number| Number of results per page, defaults to 500 
 
 ### Accepted authentication
@@ -1586,7 +1586,7 @@ Name | Type | Description
  date_taken_end | String| Show images that were taken before the specified date 
  cursor | String| The cursor of the page with which to start fetching results; this cursor is returned from previous requests 
  sort | String| Sort by, defaults to newest <br/><br/>Valid values: "newest", "oldest"
- supplier_code | [[String]](String.md)| Show only editorial content from certain suppliers 
+ supplier_code | [String]| Show only editorial content from certain suppliers
  per_page | Number| Number of results per page, defaults to 500 
 
 ### Accepted authentication
@@ -2014,7 +2014,7 @@ Name | Type | Description
  query | String| One or more search terms separated by spaces 
  sort | String| Sort by, defaults to relevant <br/><br/>Valid values: "relevant", "newest", "oldest"
  category | String| Show editorial content within a certain editorial category; specify by category name 
- supplier_code | [[String]](String.md)| Show only editorial content from certain suppliers 
+ supplier_code | [String]| Show only editorial content from certain suppliers
  date_start | Date| Show only editorial content generated on or after a specific date 
  date_end | Date| Show only editorial content generated on or before a specific date 
  per_page | Number| Number of results per page, defaults to 20 
@@ -2222,7 +2222,7 @@ Name | Type | Description
  query | String| One or more search terms separated by spaces 
  sort | String| Sort by, defaults to relevant <br/><br/>Valid values: "relevant", "newest", "oldest"
  category | String| Show editorial content within a certain editorial category; specify by category name 
- supplier_code | [[String]](String.md)| Show only editorial content from certain suppliers 
+ supplier_code | [String]| Show only editorial content from certain suppliers
  date_start | Date| Show only editorial content generated on or after a specific date 
  date_end | Date| Show only editorial content generated on or before a specific date 
  per_page | Number| Number of results per page, defaults to 20 

--- a/docs/EditorialVideoApi.md
+++ b/docs/EditorialVideoApi.md
@@ -155,7 +155,7 @@ Name | Type | Description
  query | String| One or more search terms separated by spaces 
  sort | String| Sort by, defaults to relevant <br/><br/>Valid values: "relevant", "newest", "oldest"
  category | String| Show editorial video content within a certain editorial category; specify by category name 
- supplier_code | [[String]](String.md)| Show only editorial video content from certain suppliers 
+ supplier_code | [String]| Show only editorial video content from certain suppliers
  date_start | Date| Show only editorial video content generated on or after a specific date 
  date_end | Date| Show only editorial video content generated on or before a specific date 
  resolution | String| Show only editorial video content with specific resolution <br/><br/>Valid values: "4k", "high_definition", "standard_definition"

--- a/docs/ImagesApi.md
+++ b/docs/ImagesApi.md
@@ -237,7 +237,7 @@ imagesApi.deleteLightboxItems(collectionId, imagesToRemove)
 Name | Type | Description
 ------------- | ------------- | -------------
  id (required) | String| Collection ID 
- item_id | [[String]](String.md)| One or more image IDs to remove from the collection 
+ item_id | [String]| One or more image IDs to remove from the collection
 
 ### Accepted authentication
 
@@ -529,7 +529,7 @@ api.getFeaturedLightboxList(queryParams)
 Name | Type | Description
 ------------- | ------------- | -------------
  embed | String| Which sharing information to include in the response, such as a URL to the collection <br/><br/>Valid values: "share_url"
- type | [[String]](String.md)| The types of collections to return <br/><br/>Valid values: "photo", "editorial", "vector"
+ type | [String]| The types of collections to return <br/><br/>Valid values: "photo", "editorial", "vector"
  asset_hint | String| Cover image size, defaults to 1x <br/><br/>Valid values: "1x", "2x"
 
 ### Accepted authentication
@@ -1068,7 +1068,7 @@ api.getImageList(id, queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| One or more image IDs 
+ id (required) | [String]| One or more image IDs
  view | String| Amount of detail to render in the response, defaults to minimal <br/><br/>Valid values: "minimal", "full"
 
 ### Accepted authentication
@@ -1380,7 +1380,7 @@ api.getImageRecommendations(id, queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| Image IDs 
+ id (required) | [String]| Image IDs
  max_items | Number| Maximum number of results returned in the response, defaults to 20 
  safe | Boolean| Restrict results to safe images, defaults to true 
 
@@ -1537,7 +1537,7 @@ api.getLightbox(id, queryParams)
 Name | Type | Description
 ------------- | ------------- | -------------
  id (required) | String| Collection ID 
- embed | [[String]](String.md)| Which sharing information to include in the response, such as a URL to the collection <br/><br/>Valid values: "share_code", "share_url"
+ embed | [String]| Which sharing information to include in the response, such as a URL to the collection <br/><br/>Valid values: "share_code", "share_url"
  share_code | String| Code to retrieve a shared collection 
 
 ### Accepted authentication
@@ -1697,7 +1697,7 @@ api.getLightboxList(queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- embed | [[String]](String.md)| Which sharing information to include in the response, such as a URL to the collection <br/><br/>Valid values: "share_code", "share_url"
+ embed | [String]| Which sharing information to include in the response, such as a URL to the collection <br/><br/>Valid values: "share_code", "share_url"
  page | Number| Page number, defaults to 1 
  per_page | Number| Number of results per page, defaults to 100 
 
@@ -2099,7 +2099,7 @@ imagesApi.getUpdatedImages(queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- type | [[String]](String.md)| Show images that were added, deleted, or edited; by default, the endpoint returns images that were updated in any of these ways <br/><br/>Valid values: "addition", "deletion", "edit"
+ type | [String]| Show images that were added, deleted, or edited; by default, the endpoint returns images that were updated in any of these ways <br/><br/>Valid values: "addition", "deletion", "edit"
  start_date | Date| Show images updated on or after the specified date 
  end_date | Date| Show images updated before the specified date 
  interval | String| Show images updated in the specified time period, where the time period is an interval (like SQL INTERVAL) such as 1 DAY, 6 HOUR, or 30 MINUTE; the default is 1 HOUR, which shows images that were updated in the hour preceding the request, defaults to 1 HOUR 
@@ -2444,23 +2444,23 @@ Name | Type | Description
  added_date_end | Date| Show images added before the specified date 
  category | String| Show images with the specified Shutterstock-defined category; specify a category name or ID 
  color | String| Specify either a hexadecimal color in the format '4F21EA' or 'grayscale'; the API groups it into one of 15 color categories and returns images that primarily use that color category 
- contributor | [[String]](String.md)| Show images with the specified contributor names or IDs, allows multiple 
+ contributor | [String]| Show images with the specified contributor names or IDs, allows multiple
  contributor_country | [Object](.md)| Show images from contributors in one or more specified countries, or start with NOT to exclude a country from the search 
  fields | String| Fields to display in the response; see the documentation for the fields parameter in the overview section 
  height | Number| (Deprecated; use height_from and height_to instead) Show images with the specified height 
  height_from | Number| Show images with the specified height or larger, in pixels 
  height_to | Number| Show images with the specified height or smaller, in pixels 
- image_type | [[String]](String.md)| Show images of the specified type <br/><br/>Valid values: "photo", "illustration", "vector"
+ image_type | [String]| Show images of the specified type <br/><br/>Valid values: "photo", "illustration", "vector"
  keyword_safe_search | Boolean| Hide results with potentially unsafe keywords, defaults to true 
  language | String| Set query and result language (uses Accept-Language header if not set) <br/><br/>Valid values: "cs", "da", "de", "en", "es", "fi", "fr", "hu", "it", "ja", "ko", "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr", "zh", "zh-Hant"
- license | [[String]](String.md)| Show only images with the specified license <br/><br/>Valid values: "commercial", "editorial", "enhanced"
- model | [[String]](String.md)| Show image results with the specified model IDs 
+ license | [String]| Show only images with the specified license <br/><br/>Valid values: "commercial", "editorial", "enhanced"
+ model | [String]| Show image results with the specified model IDs
  orientation | String| Show image results with horizontal or vertical orientation <br/><br/>Valid values: "horizontal", "vertical"
  page | Number| Page number, defaults to 1 
  per_page | Number| Number of results per page, defaults to 20 
  people_model_released | Boolean| Show images of people with a signed model release 
  people_age | String| Show images that feature people of the specified age category <br/><br/>Valid values: "infants", "children", "teenagers", "20s", "30s", "40s", "50s", "60s", "older"
- people_ethnicity | [[String]](String.md)| Show images with people of the specified ethnicities <br/><br/>Valid values: "african", "african_american", "black", "brazilian", "chinese", "caucasian", "east_asian", "hispanic", "japanese", "middle_eastern", "native_american", "pacific_islander", "south_asian", "southeast_asian", "other"
+ people_ethnicity | [String]| Show images with people of the specified ethnicities <br/><br/>Valid values: "african", "african_american", "black", "brazilian", "chinese", "caucasian", "east_asian", "hispanic", "japanese", "middle_eastern", "native_american", "pacific_islander", "south_asian", "southeast_asian", "other"
  people_gender | String| Show images with people of the specified gender <br/><br/>Valid values: "male", "female", "both"
  people_number | Number| Show images with the specified number of people 
  query | String| One or more search terms separated by spaces; you can use NOT to filter out images that match a term 

--- a/docs/TestApi.md
+++ b/docs/TestApi.md
@@ -100,7 +100,7 @@ api.validate(id, queryParams)
 Name | Type | Description
 ------------- | ------------- | -------------
  id (required) | Number| Integer ID 
- tag | [[String]](String.md)| List of tags 
+ tag | [String]| List of tags
  user_agent | String| User agent 
 
 ### Accepted authentication

--- a/docs/VideosApi.md
+++ b/docs/VideosApi.md
@@ -240,7 +240,7 @@ videosApi.deleteClipboxItems(collectionId, videosToRemove)
 Name | Type | Description
 ------------- | ------------- | -------------
  id (required) | String| The ID of the Collection from which items will be deleted 
- item_id | [[String]](String.md)| One or more video IDs to remove from the collection 
+ item_id | [String]| One or more video IDs to remove from the collection
 
 ### Accepted authentication
 
@@ -1370,7 +1370,7 @@ api.getVideoList(id, queryParams)
 
 Name | Type | Description
 ------------- | ------------- | -------------
- id (required) | [[String]](String.md)| One or more video IDs 
+ id (required) | [String]| One or more video IDs
  view | String| Amount of detail to render in the response, defaults to minimal <br/><br/>Valid values: "minimal", "full"
 
 ### Accepted authentication
@@ -1880,8 +1880,8 @@ Name | Type | Description
  added_date_end | Date| Show videos added before the specified date 
  aspect_ratio | String| Show videos with the specified aspect ratio <br/><br/>Valid values: "4_3", "16_9", "nonstandard"
  category | String| Show videos with the specified Shutterstock-defined category; specify a category name or ID 
- contributor | [[String]](String.md)| Show videos with the specified artist names or IDs 
- contributor_country | [[String]](String.md)| Show videos from contributors in one or more specified countries 
+ contributor | [String]| Show videos with the specified artist names or IDs
+ contributor_country | [String]| Show videos from contributors in one or more specified countries
  duration | Number| (Deprecated; use duration_from and duration_to instead) Show videos with the specified duration in seconds 
  duration_from | Number| Show videos with the specified duration or longer in seconds 
  duration_to | Number| Show videos with the specified duration or shorter in seconds 
@@ -1890,12 +1890,12 @@ Name | Type | Description
  fps_to | Number| Show videos with the specified frames per second or fewer 
  keyword_safe_search | Boolean| Hide results with potentially unsafe keywords, defaults to true 
  language | String| Set query and result language (uses Accept-Language header if not set) <br/><br/>Valid values: "cs", "da", "de", "en", "es", "fi", "fr", "hu", "it", "ja", "ko", "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr", "zh", "zh-Hant"
- license | [[String]](String.md)| Show only videos with the specified license or licenses <br/><br/>Valid values: "commercial", "editorial"
- model | [[String]](String.md)| Show videos with each of the specified models 
+ license | [String]| Show only videos with the specified license or licenses <br/><br/>Valid values: "commercial", "editorial"
+ model | [String]| Show videos with each of the specified models
  page | Number| Page number, defaults to 1 
  per_page | Number| Number of results per page, defaults to 20 
  people_age | String| Show videos that feature people of the specified age range <br/><br/>Valid values: "infants", "children", "teenagers", "20s", "30s", "40s", "50s", "60s", "older"
- people_ethnicity | [[String]](String.md)| Show videos with people of the specified ethnicities <br/><br/>Valid values: "african", "african_american", "black", "brazilian", "chinese", "caucasian", "east_asian", "hispanic", "japanese", "middle_eastern", "native_american", "pacific_islander", "south_asian", "southeast_asian", "other"
+ people_ethnicity | [String]| Show videos with people of the specified ethnicities <br/><br/>Valid values: "african", "african_american", "black", "brazilian", "chinese", "caucasian", "east_asian", "hispanic", "japanese", "middle_eastern", "native_american", "pacific_islander", "south_asian", "southeast_asian", "other"
  people_gender | String| Show videos with people with the specified gender <br/><br/>Valid values: "male", "female", "both"
  people_number | Number| Show videos with the specified number of people 
  people_model_released | Boolean| Show only videos of people with a signed model release 


### PR DESCRIPTION
Per this issue with swagger-codegen:
https://github.com/swagger-api/swagger-codegen/issues/9473
swagger codegen creates links to the nonexistent String type.

This PR fixes those temporarily. I've made a fix internally so this generated info won't have that bad link next time.