### PR TITLE
Update image test to include url in responses

### DIFF
--- a/test/system/image.js
+++ b/test/system/image.js
@@ -56,6 +56,7 @@ describe('images api', () => {
           'is_illustration',
           'keywords',
           'model_releases',
+          'url',
         );
         expect(res.description).to.deep.equal('Happy New Year 2019. Chinese New Year. ' +
           'The year of the pig. Translation: Greetings from the golden pig.');


### PR DESCRIPTION
New url parameter for showing the shutterstock.com url was added, and tests needed to be updated.